### PR TITLE
force specialization in sv_ecef_to_ecef

### DIFF
--- a/src/orbit/sv_ecef_to_ecef.jl
+++ b/src/orbit/sv_ecef_to_ecef.jl
@@ -25,7 +25,7 @@ Convert the orbit state vector `sv` from an ECEF frame to another ECEF frame.  T
 `args...` must match those of the function [`r_ecef_to_ecef`](@ref) **without** the rotation
 representation.
 """
-function sv_ecef_to_ecef(sv::OrbitStateVector, args...)
+function sv_ecef_to_ecef(sv::OrbitStateVector, args::Vararg{Any, N}) where N
     D = r_ecef_to_ecef(DCM, args...)
 
     # Since both frames does not have a significant angular velocity between


### PR DESCRIPTION
I found out that I had unexpected allocations when using the SatelliteToolbox ecosystem and I pinpointed this down to the `sv_ecef_to_ecef` function.

This small PR tries to force specialization for this function as the generic `args...` can often lead to allocations due to lack of specialization (see [this section](https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing) of the performance tips)

A benchmark of the function before and after this PR on my linux machine gives the following improvement:
```julia
# Before this PR
BenchmarkTools.Trial: 10000 samples with 162 evaluations.
 Range (min … max):  656.858 ns … 39.471 μs  ┊ GC (min … max):  0.00% … 96.59%
 Time  (median):     687.685 ns              ┊ GC (median):     0.00%
 Time  (mean ± σ):   870.394 ns ±  2.221 μs  ┊ GC (mean ± σ):  15.98% ±  6.12%

  ▅██▇▅▄▄▃▃▃▃▃▃▂▂▁▂▁▁▁                                         ▂
  ███████████████████████▇▇█▇▆▇▅▆▆▆▅▃▅▄▄▄▅▅▅▆▆▆▆▄▆▆▆▇▆▇▅▇▇█▆▆▆ █
  657 ns        Histogram: log(frequency) by time      1.31 μs <

 Memory estimate: 1.11 KiB, allocs estimate: 15.

# After this PR
BenchmarkTools.Trial: 10000 samples with 900 evaluations.
 Range (min … max):  123.292 ns … 200.348 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     126.317 ns               ┊ GC (median):    0.00%
 Time  (mean ± σ):   127.951 ns ±   6.883 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

    ▄▆█▆                                                         
  ▆█████▅▃▃▃▃▃▃▃▃▃▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▁▂▂▂▂▂▂▂▂▂▂▂▂▂ ▃
  123 ns           Histogram: frequency by time          166 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```

<details>
 <summary>Test code (taken from package tests)</summary>

```julia
using SatelliteToolboxTransformations
using BenchmarkTools

eop_iau1980  = read_iers_eop("test/eop_IAU1980.txt",  Val(:IAU1980))

JD_UTC = date_to_jd(2004, 4, 6, 7, 51, 28.386009)

# ITRF => PEF
# ======================================================================================

r_itrf  = [-1033.4793830; 7901.2952754; 6380.3565958]
v_itrf  = [-3.225636520; -2.872451450; +5.531924446]
sv_itrf = OrbitStateVector(JD_UTC, r_itrf, v_itrf)
@benchmark sv_ecef_to_ecef($sv_itrf, ITRF(), PEF(), $JD_UTC, $eop_iau1980)
```
</details>
