### PR TITLE
Update Interpolations.jl compat bound

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 Crayons = "4.0"
-Interpolations = "0.14"
+Interpolations = "0.14, 0.15"
 Reexport = "1"
 ReferenceFrameRotations = "3"
 SatelliteToolboxBase = "0.2, 0.3"


### PR DESCRIPTION
This update the Interpolations.jl compat bound to also support 0.15, which according to the [release notes](https://github.com/JuliaMath/Interpolations.jl/releases) is only breaking due to dropping suppport for julia versions prior to 1.6